### PR TITLE
Add colour to filenames and a blank link to make visually reading easier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 name = "multi-diff"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ glob = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"
+ansi_term = "0.11.0" # Version 0.11.0 already required for clap

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use std::{
     path::Path,
     rc::Rc,
 };
+use ansi_term::Colour::Green;
 
 fn app() -> App<'static, 'static> {
     clap_app!(cepler =>
@@ -40,8 +41,9 @@ pub fn run() -> anyhow::Result<()> {
     combos.dedup();
     combos.reverse();
     for combo in combos {
+        println!("");
         for file in combo.iter() {
-            println!("# {}", file);
+            println!("# {}", Green.paint(file));
         }
         println!(
             "{}",


### PR DESCRIPTION
Updated the code to add a blank line before the filename and colour it green.  This makes seeing the blocks easier when reviewing the results.